### PR TITLE
Fix when local time is ahead of UTC and improve offset calculation

### DIFF
--- a/custom_components/lywsd02/__init__.py
+++ b/custom_components/lywsd02/__init__.py
@@ -25,7 +25,9 @@ def get_localized_timestamp():
     utc = datetime.fromtimestamp(now, timezone.utc)
     local = datetime.fromtimestamp(now)
     diff = (local.replace(tzinfo=timezone.utc) - utc).total_seconds()
-    return int((utc + timedelta(seconds=diff)).timestamp())
+    diff_hours, diff_seconds = divmod(diff, 3600)
+    utc_timestamp = int((utc + timedelta(seconds=diff_seconds)).timestamp())
+    return utc_timestamp, int(diff_hours)
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """
@@ -82,10 +84,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 if tz_offset is not None:
                     timestamp = int(time.time())
                 else:
-                    tz_offset = 0
-                    timestamp = get_localized_timestamp()
+                    timestamp, tz_offset = get_localized_timestamp()
             elif tz_offset is None:
-                tz_offset = 0
+                _timestamp, tz_offset = get_localized_timestamp()
             data = struct.pack('Ib', timestamp, tz_offset)
             await client.write_gatt_char(_UUID_TIME, data)
             if temo_set:

--- a/custom_components/lywsd02/__init__.py
+++ b/custom_components/lywsd02/__init__.py
@@ -4,7 +4,7 @@ import time
 import struct
 import logging
 
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 
 from bleak import BleakClient
 
@@ -21,11 +21,11 @@ _UUID_TIME = 'EBE0CCB7-7A0A-4B0C-8A1A-6FF2997DA3A6'
 _UUID_TEMO = 'EBE0CCBE-7A0A-4B0C-8A1A-6FF2997DA3A6'
 
 def get_localized_timestamp():
-    now = int(time.time())
-    utc = datetime.utcfromtimestamp(now)
+    now = time.time()
+    utc = datetime.fromtimestamp(now, timezone.utc)
     local = datetime.fromtimestamp(now)
-    diff = (utc-local).seconds
-    return now - diff
+    diff = (local.replace(tzinfo=timezone.utc) - utc).total_seconds()
+    return int((utc + timedelta(seconds=diff)).timestamp())
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """

--- a/info.md
+++ b/info.md
@@ -38,7 +38,7 @@ data:
 
 `tz_offset` will default to 0 (UTC).
 
-`timestamp` defaults to UTC adjusted to local time disregarding the `tz_offset` setting.
+`timestamp` defaults to UTC (adjusted to local time unless `tz_offset` is set).
 
 ## Timeout
 

--- a/info.md
+++ b/info.md
@@ -36,9 +36,13 @@ data:
 
 `tz_offset` only accepts whole numbers.
 
-`tz_offset` will default to 0 (UTC).
+If you are in a whole number timezone (e.g. UTC+2, UTC-5):
+`tz_offset` defaults to your timezone offset.
+`timestamp` defaults to UTC.
 
-`timestamp` defaults to UTC (adjusted to local time unless `tz_offset` is set).
+If you are in a partial hour timezone (e.g. UTC+8:45, UTC-3:30):
+`tz_offset` defaults to rounding down your timezone offset.
+`timestamp` defaults to UTC + your partial hour offset.
 
 ## Timeout
 

--- a/info.md
+++ b/info.md
@@ -1,16 +1,16 @@
 # LYWSD02 Sync
 
-Once installed, you need to add following to HomeAssistant's `configuration.yaml` and restart it:
+Once installed, you need to add the following to Home Assistant's `configuration.yaml` and restart it:
 ```yaml
 lywsd02:
 ```
 
 ## Setting Time
 
-Now you have have `lywsd.set_time` service that can be used to set time on a LYWSD02 given its BLE MAC address.
+Now you have a `lywsd.set_time` service that can be used to set the time on a LYWSD02 given its BLE MAC address.
 
-Only MAC address parameter is requried, and it will set the time to what is on your HomeAssistant.
-Here's how the minimal invocation looks like:
+Only the MAC address parameter is required, and it will set the time to what is on your Home Assistant.
+Here's a minimal invocation:
 ```yaml
 service: lywsd02.set_time
 data:
@@ -19,12 +19,12 @@ data:
 
 Now you can setup an automation to invoke this service as often as you'd like to sync LYWSD02's time.
 
-If you want a lower-lever control - you can tweak the exact time set via additional parameters.
+If you want lower-level control - you can tweak the exact time set via additional parameters.
 See [./services.yaml](./custom_components/lywsd02/services.yaml) for details.
 
 ## Setting Unit
 
-You can also set tempaerature unit (F/C), TZ offset, as well as clock mode (12/24) via optional parameters:
+You can also set the temperature unit (F/C), TZ offset, as well as clock mode (12/24) via optional parameters:
 ```yaml
 service: lywsd02.set_time
 data:
@@ -34,9 +34,15 @@ data:
   temp_mode: 'C'
 ```
 
+`tz_offset` only accepts whole numbers.
+
+`tz_offset` will default to 0 (UTC).
+
+`timestamp` defaults to UTC adjusted to local time disregarding the `tz_offset` setting.
+
 ## Timeout
 
-If you get an error establishing connection - could be because it takes longer than expected to get the Bluetooth proxy working. Consider increasing `timeout` from default 10s to a larger value:
+If you get an error establishing a connection - it could be because it takes longer than expected to get the Bluetooth proxy working. Consider increasing `timeout` from default 10s to a larger value:
 ```yaml
 service: lywsd02.set_time
 data:


### PR DESCRIPTION
Thanks for making this. I ran into some issues setting this up.

- The time is set incorrectly when no `tz_offset` or `timestamp` is supplied, if local time is ahead of UTC.
- Setting `tz_offset` without `timestamp` results in the offset being added twice.
- While changing the timestamp logic I also added the ability to send the system offset to the clock.

Let me know if you want these as individual PRs :slightly_smiling_face: 

## Fix for Positive System Timezone Offsets
Addressed a bug where, if the local time is ahead of UTC, the previous implementation would incorrectly wrap the time due to the use of `.seconds` on a negative timedelta. The logic now properly handles positive offsets.

## Send UTC time when `tz_offset` is specified
Fixed an issue where supplying `tz_offset` without a `timestamp` would result in the clock displaying a doubly offset time. Now, when `tz_offset` is provided, the UTC timestamp is used.

## Send Clock Calculated UTC Offset
The UTC offset is now calculated based on the local timezone, rather than being set to zero by default. For users in timezones with non-whole hour offsets, the code now falls back to sending the partial hour offset as an adjusted UTC value.

## Tests
<details>

<summary>Some tests for the new timestamp calculation</summary>

I wanted to ensure the new implementation of `get_localized_timestamp` works correctly across various timezones.

The tests for +5.5 and +10 will fail on the old implementation.

```python
from datetime import datetime, timezone, timedelta
from freezegun import freeze_time
import time


def get_localized_timestamp():
    now = int(time.time())
    utc = datetime.utcfromtimestamp(now)
    local = datetime.fromtimestamp(now)
    diff = (utc - local).seconds
    return now - diff


def v2_get_localized_timestamp():
    now = time.time()
    utc = datetime.fromtimestamp(now, timezone.utc)
    local = datetime.fromtimestamp(now)
    diff = (local.replace(tzinfo=timezone.utc) - utc).total_seconds()
    return int((utc + timedelta(seconds=diff)).timestamp())


def test_localized_timestamp():
    _test_localized_timestamp_implementation(get_localized_timestamp, "current")


def test_v2_localized_timestamp():
    _test_localized_timestamp_implementation(v2_get_localized_timestamp, "new")


def _test_localized_timestamp_implementation(func, implementation_name):
    fixed_time = 1751007289
    failures = []

    for offset in [-10, -5.5, 0, 5.5, 10]:
        with freeze_time(
            datetime.fromtimestamp(fixed_time, timezone.utc), tz_offset=offset
        ):
            expected = fixed_time + int(offset * 3600)
            result = func()

            if result != expected:
                failures.append(
                    f"Offset={offset}: expected {expected}, got {result} (difference {expected - result} seconds)"
                )

    if failures:
        failure_msg = "\n".join(failures)
        assert False, (
            f"{implementation_name.capitalize()} implementation failed for {len(failures)} timezone(s):\n{failure_msg}"
        )


def v3_get_localized_timestamp():
    now = time.time()
    utc = datetime.fromtimestamp(now, timezone.utc)
    local = datetime.fromtimestamp(now)
    diff = (local.replace(tzinfo=timezone.utc) - utc).total_seconds()
    diff_hours, diff_seconds = divmod(diff, 3600)
    utc_timestamp = int((utc + timedelta(seconds=diff_seconds)).timestamp())
    return utc_timestamp, int(diff_hours)


def test_v3_localized_timestamp():
    fixed_time = 1751007289
    failures = []

    for offset, expected_hours, expected_seconds in [
        [-10, -10, 0],
        [-5.5, -6, 1800],
        [0, 0, 0],
        [5.5, 5, 1800],
        [10, 10, 0],
    ]:
        with freeze_time(
            datetime.fromtimestamp(fixed_time, timezone.utc), tz_offset=offset
        ):
            timestamp, diff_hours = v3_get_localized_timestamp()

            expected_result = fixed_time + expected_seconds

            if timestamp != expected_result or diff_hours != expected_hours:
                failures.append(
                    f"Offset={offset}: expected ts={expected_result}, got ts={timestamp} (diff {expected_result - timestamp} s); expected hours={expected_hours}, got hours={diff_hours}"
                )

    if failures:
        failure_msg = "\n".join(failures)
        assert False, (
            f"V3 implementation failed for {len(failures)} timezone(s):\n{failure_msg}"
        )
```

</details>